### PR TITLE
[bugfix] typo in exception class namespace

### DIFF
--- a/lib/Voximplant/Transport/Curl.php
+++ b/lib/Voximplant/Transport/Curl.php
@@ -2,7 +2,7 @@
 
 namespace Voximplant\Transport;
 
-use Voximplant\Transport\TransportException;
+use Voximplant\Exception\TransportException;
 
 class Curl implements Transport
 {


### PR DESCRIPTION
ClassNotFoundException was thrown instead of TransportException
